### PR TITLE
Update map rl_window_map type to BPF_MAP_TYPE_LRU_HASH

### DIFF
--- a/ratelimiting/ratelimiting_kern.c
+++ b/ratelimiting/ratelimiting_kern.c
@@ -36,10 +36,10 @@ struct bpf_map_def SEC("maps") rl_config_map = {
 /* Maintains the timestamp of a window and the total number of
  * connections received in that window(window = 1 sec interval) */
 struct bpf_map_def SEC("maps") rl_window_map = {
-	.type		= BPF_MAP_TYPE_HASH,
+	.type		= BPF_MAP_TYPE_LRU_HASH,
 	.key_size	= sizeof(uint64_t),
 	.value_size	= sizeof(uint64_t),
-	.max_entries	= 100,
+	.max_entries	= 1000,
 };
 
 /* Maintains the total number of connections received(TCP-SYNs)

--- a/ratelimiting/ratelimiting_user.c
+++ b/ratelimiting/ratelimiting_user.c
@@ -192,33 +192,6 @@ static __u64 time_get_ns(void)
 #endif
 }
 
-/* Delete stale map entries(LRU) based on the timestamp at which
- * a map element is created. */
-static void delete_stale_entries(void)
-{
-    log_debug("Deleting stale map entries periodically");
-
-    if (map_fd[1] < 0) {
-        log_info("Window map fd not found");
-        exit(EXIT_FAILURE);
-    }
-
-    __u64 first_key = 0, next_key = 0;
-    __u64 curr_time = time_get_ns();
-    log_debug("Current time is %llu", curr_time);
-
-    while (!bpf_map_get_next_key(map_fd[1], &first_key, &next_key))
-    {
-        if (next_key < (curr_time - buffer_time)) {
-            log_debug("Deleting stale map entry %llu", next_key);
-            if (bpf_map_delete_elem(map_fd[1], &next_key) != 0) {
-                log_info("Map element not found");
-            }
-        }
-        first_key = next_key;
-    }
-}
-
 static char* trim_space(char *str) {
     char *end;
     /* skip leading whitespace */
@@ -399,19 +372,14 @@ int main(int argc, char **argv)
         update_ports(ports);
     }
 
+    fflush(info);
     /* Handle signals and exit clean */
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
 #ifdef __linux__
     signal(SIGHUP, signal_handler);
+    pause();
+#elif WIN32
+    Sleep(INFINITE);
 #endif
-
-    while(1)
-    {
-        sleep(60);
-        /* Keep deleting the stale map entries periodically *
-         * TODO Check if LRU maps can be used.              */
-        delete_stale_entries();
-        fflush(info);
-    }
 }


### PR DESCRIPTION
This PR changes the type of the map rl_window_map to BPF_MAP_TYPE_LRU_HASH and removes the method used to delete stale map entries in the user program.
Close #39 