### PR TITLE
Fixed interface name validation checks in tc-root

### DIFF
--- a/tc-root/tc_root_user.c
+++ b/tc-root/tc_root_user.c
@@ -207,10 +207,14 @@ static bool validate_ifname(const char *input_ifname, char *output_ifname) {
     if (len >= IF_NAMESIZE) {
         return false;
     }
+    // check if interface name is null
+    if (*input_ifname == '\0') {
+        return false;
+    }
     for (i = 0; i < len; i++) {
         char c = input_ifname[i];
-
-        if (!(isalpha(c) || isdigit(c) || c == '-'))
+        // Check for each character of input_ifname  if it contains '/' or whitespace characters
+        if (c == '/' || isspace(c))
             return false;
     }
     strncpy(output_ifname, input_ifname, len);

--- a/tc-root/tc_root_user.c
+++ b/tc-root/tc_root_user.c
@@ -210,7 +210,7 @@ static bool validate_ifname(const char *input_ifname, char *output_ifname) {
     for (i = 0; i < len; i++) {
         char c = input_ifname[i];
 
-        if (!(isalpha(c) || isdigit(c)))
+        if (!(isalpha(c) || isdigit(c) || c == '-'))
             return false;
     }
     strncpy(output_ifname, input_ifname, len);


### PR DESCRIPTION
This PR fixed #25 , which concerns the limitation of tc-root to only allow attachment to interfaces with names containing alphabets or digits, but not hyphens. In the context of hypervisors, tap interfaces commonly contain hyphens, which currently prevents tc-root from attaching to them.

To fix this issue, I have modified the tc-root code to support interface names with hyphens as well. With this change, tc-root will now be able to attach to all interfaces, regardless of their name format.

Please review the changes and let me know if any further modifications are required. Thank you for your attention to this matter.

Signed-off-by: SHANKAR <shankar.s@ramanujan.du.ac.in>