### PR TITLE
Update the codeowner list as proposed in the 8/8/2023 TSC.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Code owners
-* @jniesz @sanfern @jaysheth2 @aka320
+* @jniesz @sanfern @jaysheth2 @aka320 @dalalkaran @binojrajan


### PR DESCRIPTION
In this PR, Karan Dalal and Binoj Ranjan are added to the codeowners list as proposed in the TSC meeting on 8/8/2023.