### PR TITLE
fixing multiple declaration conflict while configuring for m1

### DIFF
--- a/ipfix-flow-exporter/bpf_ipfix_egress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_egress_user.c
@@ -14,9 +14,7 @@ static const char *__doc__=" BPF IPFIX : To get packet flow data by handling the
 #define EXIT_FAIL               1
 
 const char egress[] = "egress_flow_monitoring";
-FILE *info;
-int verbosity;
-int if_idx;
+
 /* Ingress Specific variables */
 bool attach_tc_egress_filter = false;
 char if_name[IF_NAMESIZE];

--- a/ipfix-flow-exporter/bpf_ipfix_egress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_egress_user.c
@@ -14,9 +14,9 @@ static const char *__doc__=" BPF IPFIX : To get packet flow data by handling the
 #define EXIT_FAIL               1
 
 const char egress[] = "egress_flow_monitoring";
-extern FILE *info;
-extern int verbosity;
-
+FILE *info;
+int verbosity;
+int if_idx;
 /* Ingress Specific variables */
 bool attach_tc_egress_filter = false;
 char if_name[IF_NAMESIZE];

--- a/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
@@ -12,9 +12,7 @@ static const char *__doc__=" BPF IPFIX : To get packet flow data by handling the
 /* Exit return codes */
 #define EXIT_OK                 0
 #define EXIT_FAIL               1
-int if_idx;
-FILE *info;
-int verbosity;
+
 const char ingress[] = "ingress_flow_monitoring";
 
 /* Ingress Specific variables */

--- a/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
@@ -12,9 +12,9 @@ static const char *__doc__=" BPF IPFIX : To get packet flow data by handling the
 /* Exit return codes */
 #define EXIT_OK                 0
 #define EXIT_FAIL               1
-
-extern FILE *info;
-extern int verbosity;
+int if_idx;
+FILE *info;
+int verbosity;
 const char ingress[] = "ingress_flow_monitoring";
 
 /* Ingress Specific variables */

--- a/ipfix-flow-exporter/bpf_ipfix_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_user.c
@@ -27,6 +27,7 @@ int bpf_map_fd = -1;
 int egress_fd = -1, last_egress_fd = -1, ingress_fd = -1, last_ingress_fd = -1;
 int flow_timeout_counter = 3;
 char *tc_cmd = "tc";
+int if_idx;
 
 const struct option long_options[] = {
     {"help",         no_argument, NULL, 'h' },
@@ -44,8 +45,8 @@ const struct option long_options[] = {
 const char* ingress_sec = "ingress_flow_monitoring";
 const char* egress_sec =  "egress_flow_monitoring";
 
-extern FILE *info;
-extern int verbosity;
+FILE *info;
+int verbosity;
 
 static flow_record_t *flow_rec_to_create_ipfix = NULL;
 
@@ -116,9 +117,9 @@ bool delete_inactive_flow(int flow_idle_counter, int map_fd, int last_map_fd, un
 int get_port(int dir) {
     int port = 0;
     if (dir == INGRESS)
-	 port = IPFIX_EXPORT_INGRESS_LOCAL_PORT;
+	 port = IPFIX_EXPORT_INGRESS_LOCAL_PORT ;
     else if (dir == EGRESS)
-	 port = IPFIX_EXPORT_EGRESS_LOCAL_PORT;
+	 port = IPFIX_EXPORT_EGRESS_LOCAL_PORT ;
 
     return port;
 }

--- a/ipfix-flow-exporter/bpf_ipfix_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_user.c
@@ -17,8 +17,7 @@ const char* bpf_path = "/sys/fs/bpf/";
 const char* ingress_dir = "ingress";
 const char* egress_dir = "egress";
 
-int ipfix_export_ingress_local_port = 4755;
-int ipfix_export_egress_local_port = 4756;
+
 bool chain = false;
 char* remote_ip = NULL;
 char* bpf_map_file_path = NULL;
@@ -117,9 +116,9 @@ bool delete_inactive_flow(int flow_idle_counter, int map_fd, int last_map_fd, un
 int get_port(int dir) {
     int port = 0;
     if (dir == INGRESS)
-	 port = ipfix_export_ingress_local_port;
+	 port = IPFIX_EXPORT_INGRESS_LOCAL_PORT;
     else if (dir == EGRESS)
-	 port = ipfix_export_egress_local_port;
+	 port = IPFIX_EXPORT_EGRESS_LOCAL_PORT;
 
     return port;
 }

--- a/ipfix-flow-exporter/bpf_ipfix_user.h
+++ b/ipfix-flow-exporter/bpf_ipfix_user.h
@@ -42,6 +42,7 @@ extern const char* ipfix_egress_jmp_table;
 extern const char* bpf_path;
 extern const char* ingress_dir;
 extern const char* egress_dir;
+
 extern bool chain;
 extern char *remote_ip, *bpf_map_file_path, *tc_cmd;
 extern int flow_timeout, remote_port, bpf_map_fd;

--- a/ipfix-flow-exporter/bpf_ipfix_user.h
+++ b/ipfix-flow-exporter/bpf_ipfix_user.h
@@ -30,6 +30,9 @@
 #include "bpf_load.h"
 #include "bpf_util.h"
 
+#define IPFIX_EXPORT_INGRESS_LOCAL_PORT 4755
+#define IPFIX_EXPORT_EGRESS_LOCAL_PORT 4756
+
 extern const char* egress_bpf_map ;
 extern const char* last_egress_bpf_map ;
 extern const char* ingress_bpf_map ;
@@ -39,8 +42,6 @@ extern const char* ipfix_egress_jmp_table;
 extern const char* bpf_path;
 extern const char* ingress_dir;
 extern const char* egress_dir;
-
-extern int ipfix_export_ingress_local_port, ipfix_export_egress_local_port;
 extern bool chain;
 extern char *remote_ip, *bpf_map_file_path, *tc_cmd;
 extern int flow_timeout, remote_port, bpf_map_fd;

--- a/ipfix-flow-exporter/bpf_ipfix_user.h
+++ b/ipfix-flow-exporter/bpf_ipfix_user.h
@@ -30,22 +30,22 @@
 #include "bpf_load.h"
 #include "bpf_util.h"
 
-const char* egress_bpf_map ;
-const char* last_egress_bpf_map ;
-const char* ingress_bpf_map ;
-const char* last_ingress_bpf_map ;
-const char* ipfix_ingress_jmp_table;
-const char* ipfix_egress_jmp_table;
-const char* bpf_path;
-const char* ingress_dir;
-const char* egress_dir;
+extern const char* egress_bpf_map ;
+extern const char* last_egress_bpf_map ;
+extern const char* ingress_bpf_map ;
+extern const char* last_ingress_bpf_map ;
+extern const char* ipfix_ingress_jmp_table;
+extern const char* ipfix_egress_jmp_table;
+extern const char* bpf_path;
+extern const char* ingress_dir;
+extern const char* egress_dir;
 
-int ipfix_export_ingress_local_port, ipfix_export_egress_local_port;
-bool chain;
-char *remote_ip, *bpf_map_file_path, *tc_cmd;
-int flow_timeout, remote_port, bpf_map_fd;
-int egress_fd, last_egress_fd, ingress_fd, last_ingress_fd;
-int flow_timeout_counter, if_idx;
+extern int ipfix_export_ingress_local_port, ipfix_export_egress_local_port;
+extern bool chain;
+extern char *remote_ip, *bpf_map_file_path, *tc_cmd;
+extern int flow_timeout, remote_port, bpf_map_fd;
+extern int egress_fd, last_egress_fd, ingress_fd, last_ingress_fd;
+extern int flow_timeout_counter, if_idx;
 extern const struct option long_options[];
 
 enum iface_direction {

--- a/ipfix-flow-exporter/log.h
+++ b/ipfix-flow-exporter/log.h
@@ -18,7 +18,7 @@
 #define DATE_LEN 21
 #define TIMESTAMP_LEN 64
 
-FILE *info;
+extern FILE *info;
 
 typedef enum log_level {
     LOG_OFF = 0,
@@ -35,7 +35,7 @@ typedef enum log_level {
 #define LOG_ERR_STR "ERR"
 #define LOG_CRIT_STR "CRIT"
 
-int verbosity ;
+extern int verbosity ;
 
 #define log_debug(...) { \
         if (verbosity != LOG_OFF && verbosity <= LOG_DEBUG) { \


### PR DESCRIPTION
When we run the `make` command to compile the binary, we encounter a "multiple declaration" error. This PR aims to resolve that issue in m1. issue #60.


At first, we encountered an issue with linking due to the presence of multiple declarations resulting from defining variables in the header file. Whenever we attempted to include the header file in multiple files, the variables were created multiple times, leading to a linking error during the binary compilation process. To rectify this issue, we can declare the variables with extern in the header file and define them in one of the source files. Once done, we can use the variables in any source file where the header file is included.

In C, the distinction between a definition and a declaration is that a definition reserves space for the variable, while a declaration simply introduces the variable into the symbol table (and will prompt the linker to search for it during linking).