### PR TITLE
Update loading and chaining of the ipfix flow exporter

### DIFF
--- a/ipfix-flow-exporter/bpf_ipfix_egress_kern.c
+++ b/ipfix-flow-exporter/bpf_ipfix_egress_kern.c
@@ -1,6 +1,8 @@
 // Copyright Contributors to the L3AF Project.
 // SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
 
+#define KBUILD_MODNAME "foo"
+
 #include <uapi/linux/bpf.h>
 #include <uapi/linux/if_ether.h>
 #include <uapi/linux/if_packet.h>
@@ -16,48 +18,8 @@
 #include "bpf_ipfix_kern_common.h"
 
 #define DEBUG 1
-
 #define EGRESS 1
-
 #define ICMP 1
-
-#define bpf_printk(fmt, ...)                                    \
-({                                                              \
-               char ____fmt[] = fmt;                            \
-               bpf_trace_printk(____fmt, sizeof(____fmt),       \
-                                ##__VA_ARGS__);                 \
-})
-
-#define PIN_GLOBAL_NS 2
-#define PIN_OBJECT_NS  1
-
-
-/* EGRESS MAP FOR FLOW RECORD INFO */
-struct bpf_elf_map SEC("maps")  egress_flow_record_info_map = {
-    .type           = BPF_MAP_TYPE_HASH,
-    .size_key       = sizeof(u32),
-    .size_value     = sizeof(flow_record_t),
-    .pinning        = PIN_GLOBAL_NS,
-    .max_elem       = 30000,
-};
-
-/* EGRESS MAP FOR LAST RECORD PACKET INFO */
-struct bpf_elf_map SEC("maps")  last_egress_flow_record_info_map = {
-    .type           = BPF_MAP_TYPE_HASH,
-    .size_key       = sizeof(u32),
-    .size_value     = sizeof(flow_record_t),
-    .pinning        = PIN_GLOBAL_NS,
-    .max_elem       = 30000,
-};
-
-/* EGRESS MAP FOR CHAINING */
-struct bpf_elf_map SEC("maps") ipfix_egress_jmp_table = {
-        .type = BPF_MAP_TYPE_PROG_ARRAY,
-        .size_key = sizeof(u32),
-        .size_value = sizeof(u32),
-        .pinning = PIN_GLOBAL_NS,
-        .max_elem = 1
-};
 
 #define TCP_FIN  0x01
 #define TCP_SYN  0x02
@@ -79,12 +41,36 @@ struct bpf_elf_map SEC("maps") ipfix_egress_jmp_table = {
 
 #define TCP_FLAGS (TCP_FIN|TCP_SYN|TCP_RST|TCP_ACK|TCP_URG|TCP_ECE|TCP_CWR)
 
+/* EGRESS MAP FOR FLOW RECORD INFO */
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, flow_record_t);
+    __uint(max_entries, MAX_RECORDS);
+} egress_flow_record_info_map SEC(".maps");
+
+/* EGRESS MAP FOR LAST RECORD PACKET INFO */
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u32);
+    __type(value, flow_record_t);
+    __uint(max_entries, MAX_RECORDS);
+} last_egress_flow_record_info_map SEC(".maps");
+
+/* EGRESS MAP FOR CHAINING */
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 1);
+} ipfix_egress_jmp_table SEC(".maps");
+
 static u32 flow_key_hash (const flow_key_t f) {
     u32 hash_val = (((u32)f.sa * 0xef6e15aa)
                 ^((u32)f.da * 0x65cd52a0)
                 ^ ((u32)f.sp * 0x8216)
                 ^ ((u32)f.dp * 0xdda37)
-                ^ ((u32)f.prot * 0xbc06)) ;
+                ^ ((u32)f.prot * 0xbc06));
     return hash_val;
 }
 
@@ -305,7 +291,7 @@ static __always_inline bool parse_egress_eth(struct ethhdr *eth, void *data_end,
     return true;
 }
 
-SEC("egress_flow_monitoring")
+SEC("tc_egress_flow_monitoring")
 int _egress_flow_monitoring(struct __sk_buff *skb)
 {
     void *data     = (void *)(long)skb->data;

--- a/ipfix-flow-exporter/bpf_ipfix_egress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_egress_user.c
@@ -13,26 +13,27 @@ static const char *__doc__=" BPF IPFIX : To get packet flow data by handling the
 #define EXIT_OK                 0
 #define EXIT_FAIL               1
 
-const char egress[] = "egress_flow_monitoring";
-
 /* Ingress Specific variables */
-bool attach_tc_egress_filter = false;
 char if_name[IF_NAMESIZE];
-char *egress_log_file_path = "/var/log/tb/l3af/egress_ipfix.log";
+char *egress_log_file_path = "/var/log/l3af/egress_ipfix.log";
 
 void sig_handler(int signo)
 {
     log_info("Received shutdown signal, cleaning up");
     flow_record_poll(egress_fd, last_egress_fd, EGRESS);
-    if (attach_tc_egress_filter)
-        tc_cleanup(chain, if_name, EGRESS, egress_bpf_map, last_egress_bpf_map, bpf_map_file_path, ipfix_egress_jmp_table);
     log_info("Cleaned up");
     close_logfile();
     exit(EXIT_SUCCESS);
 }
 
 int populate_egress_fds(void) {
-    egress_fd = bpf_obj_get(egress_bpf_map);
+    char map_file[MAP_PATH_SIZE];
+    if (get_bpf_map_file(if_name, egress_bpf_map, map_file) < 0) {
+        fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
+        return EXIT_FAILURE;
+    }
+
+    egress_fd = bpf_obj_get(&map_file);
     if (egress_fd < 0) {
         fprintf(stderr, "ERROR: cannot open bpf_obj_get(%s)",
                         egress_bpf_map);
@@ -40,7 +41,11 @@ int populate_egress_fds(void) {
         return EXIT_FAILURE;
     }
 
-    last_egress_fd = bpf_obj_get(last_egress_bpf_map);
+    if (get_bpf_map_file(if_name, last_egress_bpf_map, map_file) < 0) {
+        fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
+        return EXIT_FAILURE;
+    }
+    last_egress_fd = bpf_obj_get(&map_file);
     if (last_egress_fd < 0) {
         fprintf(stderr, "ERROR: cannot open bpf_obj_get(%s)", last_egress_bpf_map);
         close_logfile();
@@ -51,9 +56,7 @@ int populate_egress_fds(void) {
 
 int main(int argc, char **argv)
 {
-    char filename[256];
     int  opt = 0, long_index = 0, l = 0;
-    bool remove_egress_tc_filter = false;
     verbosity = LOG_INFO;
     long flow_timeout = 0;
     char *eptr;
@@ -61,15 +64,6 @@ int main(int argc, char **argv)
     while ((opt = getopt_long(argc, argv, "hq",
                   long_options, &long_index)) != -1) {
         switch (opt) {
-            case 'm':
-                if(optarg){
-                    bpf_map_file_path = (char *) malloc(1 + strnlen(optarg, MAX_FILENAME_LENGTH));
-                    cpy(optarg, bpf_map_file_path);
-                    if(!validate_map_name(bpf_map_file_path))
-                        return EXIT_FAILURE;
-                    chain = true;
-                }
-                break;
             case 'q':
                 if(optarg)
                     verbosity = (int)(strtol(optarg, &eptr, 10));
@@ -85,31 +79,15 @@ int main(int argc, char **argv)
                         if_name);
                     return EXIT_FAILURE;
                 }
-                attach_tc_egress_filter = true;
-                snprintf(filename, sizeof(filename), "%s_kern.o", argv[0]);
-                l = get_length(filename);
-                filename[l] = '\0';
                 break;
             case 'c':
                 if(optarg)
                     remote_ip = optarg;
                 break;
-            case 'r':
-                if (optarg &&
-                    (!validate_ifname(optarg, (char *)&if_name))) {
-                    log_err("ERR: input --remove=ifname invalid");
-                    return EXIT_FAILURE;
-                }
-                if (get_length(if_name) == 0) {
-                    log_err("ERR: need input --list=ifname");
-                    return EXIT_FAILURE;
-                }
-                remove_egress_tc_filter = true;
-                break;
             case 't':
                 if(optarg) {
                     flow_timeout = strtol(optarg, &eptr, 10);
-		    flow_timeout_counter = flow_timeout / 10;
+                    flow_timeout_counter = flow_timeout / 10;
 		}
                 break;
             case 'p':
@@ -132,37 +110,15 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    if(attach_tc_egress_filter) {
-	if(chain == true){
-            if (tc_chain_bpf(bpf_map_file_path, filename, egress) != 1) {
-                fprintf(stderr, "ERR: tc chain egress failed \n");
-                close_logfile();
-                 return EXIT_FAILURE;
-            }
-	}
-        else {
-            if (tc_attach_filter(if_name, filename, EGRESS, egress) != 1) {
-                fprintf(stderr, "ERR: TC EGRESS filter attach failed\n");
-                close_logfile();
-                return EXIT_FAILURE;
-            }
-       }
-       if (populate_egress_fds() == EXIT_FAILURE) {
-            fprintf(stderr, "ERR: Fetching TC EGRESS maps failed\n");
-            close_logfile();
-            return EXIT_FAILURE;
-       }
-       if (remote_ip == NULL) {
-                log_info("Remote IP is not configured by user, so configuring localhost as remote_ip");
-                remote_ip = "127.0.0.1" ;
-       }
+    if (populate_egress_fds() == EXIT_FAILURE) {
+        fprintf(stderr, "ERR: Fetching TC EGRESS maps failed\n");
+        close_logfile();
+        return EXIT_FAILURE;
     }
-
-    if (remove_egress_tc_filter) {
-        log_debug("TC remove egress filters on device %s",
-                   if_name);
-        tc_remove_filter(if_name, EGRESS);
-        return EXIT_SUCCESS;
+    if (remote_ip == NULL) {
+        log_err("Remote IP is not configured by user, Please provide the remote ip");
+        close_logfile();
+        return EXIT_FAILURE;
     }
 
     if (signal(SIGINT, sig_handler) ||

--- a/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
@@ -13,32 +13,37 @@ static const char *__doc__=" BPF IPFIX : To get packet flow data by handling the
 #define EXIT_OK                 0
 #define EXIT_FAIL               1
 
-const char ingress[] = "ingress_flow_monitoring";
-
 /* Ingress Specific variables */
-char *ingress_log_file_path = "/var/log/tb/l3af/ingress_ipfix.log";
-bool attach_tc_ingress_filter = false;
+char *ingress_log_file_path = "/var/log/l3af/ingress_ipfix.log";
 char if_name[IF_NAMESIZE];
 
 void sig_handler(int signo)
 {
     log_info("Received shutdown signal, cleaning up");
     flow_record_poll(ingress_fd, last_ingress_fd, INGRESS);
-    if (attach_tc_ingress_filter)
-        tc_cleanup(chain, if_name, INGRESS, ingress_bpf_map, last_ingress_bpf_map, bpf_map_file_path, ipfix_ingress_jmp_table);
     close_logfile();
     exit(EXIT_SUCCESS);
 }
 
 int populate_ingress_fds(void) {
-    ingress_fd = bpf_obj_get(ingress_bpf_map);
+    char map_file[MAP_PATH_SIZE];
+    if (get_bpf_map_file(if_name, ingress_bpf_map, map_file) < 0) {
+        fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
+        return EXIT_FAILURE;
+    }
+
+    ingress_fd = bpf_obj_get(&map_file);
     if (ingress_fd < 0) {
         fprintf(stderr, "ERROR: cannot open bpf_obj_get(%s)", ingress_bpf_map);
         close_logfile();
         return EXIT_FAILURE;
     }
 
-    last_ingress_fd = bpf_obj_get(last_ingress_bpf_map);
+    if (get_bpf_map_file(if_name, last_ingress_bpf_map, map_file) < 0) {
+        fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
+        return EXIT_FAILURE;
+    }
+    last_ingress_fd = bpf_obj_get(&map_file);
     if (last_ingress_fd < 0) {
         fprintf(stderr, "ERROR: cannot open bpf_obj_get(%s)", last_ingress_bpf_map);
         close_logfile();
@@ -49,9 +54,7 @@ int populate_ingress_fds(void) {
 
 int main(int argc, char **argv)
 {
-    char filename[256];
     int  opt = 0, long_index = 0, l = 0;
-    bool remove_ingress_tc_filter = false;
     verbosity = LOG_INFO;
     long flow_timeout = 0;
     char *eptr;
@@ -60,15 +63,6 @@ int main(int argc, char **argv)
     while ((opt = getopt_long(argc, argv, "hq",
                   long_options, &long_index)) != -1) {
         switch (opt) {
-            case 'm':
-                if(optarg) {
-                    bpf_map_file_path = (char *) malloc(1 + strnlen(optarg, MAX_FILENAME_LENGTH));
-                    cpy(optarg, bpf_map_file_path);
-                    if(!isFileExists(bpf_map_file_path))
-                        return EXIT_FAILURE;
-                    chain = true;
-                }
-                break;
             case 'q':
                 if(optarg)
                     verbosity = (int)(strtol(optarg, &eptr, 10));
@@ -84,32 +78,16 @@ int main(int argc, char **argv)
                         if_name);
                     return EXIT_FAILURE;
                 }
-                attach_tc_ingress_filter = true;
-                snprintf(filename, sizeof(filename), "%s_kern.o", argv[0]);
-                l = get_length(filename);
-                filename[l] = '\0';
                 break;
             case 'c':
                 if(optarg)
                     remote_ip = optarg;
                 break;
-            case 'r':
-                if (optarg &&
-                    !validate_ifname(optarg, (char *)&if_name)) {
-                    log_err("ERR: input --remove=ifname invalid");
-                    return EXIT_FAILURE;
-                }
-                if (get_length(if_name) == 0) {
-                    log_err("ERR: need input --list=ifname");
-                    return EXIT_FAILURE;
-                }
-                remove_ingress_tc_filter = true;
-                break;
             case 't':
                 if(optarg) {
                     flow_timeout = strtol(optarg, &eptr, 10);
-		    flow_timeout_counter = flow_timeout / 10;
-		}
+                    flow_timeout_counter = flow_timeout / 10;
+                }
                 break;
             case 'p':
                 if(optarg)
@@ -132,36 +110,15 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    if(attach_tc_ingress_filter) {
-	if(chain == true){
-            if (tc_chain_bpf(bpf_map_file_path, filename, ingress) != 1) {
-                fprintf(stderr, "ERR: tc chain ingress failed \n");
-                close_logfile();
-                return EXIT_FAILURE;
-            }
-	}
-        else {
-            if (tc_attach_filter(if_name, filename, INGRESS, ingress) != 1) {
-                fprintf(stderr, "ERR: TC INGRESS filter attach failed\n");
-                close_logfile();
-                return EXIT_FAILURE;
-            }
-       }
-       if (populate_ingress_fds() == EXIT_FAILURE) {
-            fprintf(stderr, "ERR: Fetching TC INGRESS maps failed\n");
-            close_logfile();
-            return EXIT_FAILURE;
-       }
-       if (remote_ip == NULL) {
-                log_info("Remote IP is not configured by user, so configuring localhost as remote_ip");
-                remote_ip = "127.0.0.1" ;
-       }
+    if (populate_ingress_fds() == EXIT_FAILURE) {
+        fprintf(stderr, "ERR: Fetching TC INGRESS maps failed\n");
+        close_logfile();
+        return EXIT_FAILURE;
     }
-
-    if (remove_ingress_tc_filter) {
-        log_debug("TC remove ingress filters on device %s", if_name);
-        tc_remove_filter(if_name, INGRESS);
-        return EXIT_SUCCESS;
+    if (remote_ip == NULL) {
+        log_info("Remote IP is not configured by user, Please provide the remote_ip");
+        close_logfile();
+        return EXIT_FAILURE;
     }
 
     if (signal(SIGINT, sig_handler) || signal(SIGHUP, sig_handler) ||

--- a/ipfix-flow-exporter/bpf_ipfix_kern_common.h
+++ b/ipfix-flow-exporter/bpf_ipfix_kern_common.h
@@ -4,6 +4,8 @@
 #ifndef BPF_IPFIX_KERN_COMMON_H
 #define BPF_IPFIX_KERN_COMMON_H
 
+#define MAX_RECORDS 30000
+
 typedef struct flow_key_ {
     u32 sa;
     u32 da;

--- a/ipfix-flow-exporter/bpf_ipfix_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_user.c
@@ -7,16 +7,12 @@
 #define CMD_MAX 2048
 #define MAX_LENGTH 256
 
-const char* egress_bpf_map = "/sys/fs/bpf/tc/globals/egress_flow_record_info_map";
-const char* last_egress_bpf_map = "/sys/fs/bpf/tc/globals/last_egress_flow_record_info_map";
-const char* ingress_bpf_map = "/sys/fs/bpf/tc/globals/ingress_flow_record_info_map";
-const char* last_ingress_bpf_map = "/sys/fs/bpf/tc/globals/last_ingress_flow_record_info_map";
-const char* ipfix_ingress_jmp_table = "/sys/fs/bpf/tc/globals/ipfix_ingress_jmp_table";
-const char* ipfix_egress_jmp_table = "/sys/fs/bpf/tc/globals/ipfix_egress_jmp_table";
-const char* bpf_path = "/sys/fs/bpf/";
-const char* ingress_dir = "ingress";
-const char* egress_dir = "egress";
-
+const char* egress_bpf_map = "egress_flow_record_info_map";
+const char* last_egress_bpf_map = "last_egress_flow_record_info_map";
+const char* ingress_bpf_map = "ingress_flow_record_info_map";
+const char* last_ingress_bpf_map = "last_ingress_flow_record_info_map";
+const char* ipfix_ingress_jmp_table = "ipfix_ingress_jmp_table";
+const char* ipfix_egress_jmp_table = "ipfix_egress_jmp_table";
 
 bool chain = false;
 char* remote_ip = NULL;
@@ -35,9 +31,7 @@ const struct option long_options[] = {
     {"collector_ip", required_argument, NULL, 'c' },
     {"direction", required_argument, NULL, 'd' },
     {"collector_port", required_argument, NULL, 'p' },
-    {"tc-remove",    optional_argument, NULL, 'r' },
     {"flow-timeout", optional_argument, NULL, 't' },
-    {"map-name", optional_argument, NULL, 'm' },
     {"verbose (allowed 0-4, 0-NO_LOG,1-LOG_DEBUG,2-LOG_INFO,3-LOG_WARN,4-LOG_ERR,5-LOG_CRIT)", optional_argument, NULL, 'q' },
     {0, 0, NULL,  0 }
 };
@@ -211,94 +205,6 @@ int validate_filter_args(const char* dev)
     return ret;
 }
 
-int tc_attach_filter(const char* dev, const char* bpf_obj, int dir, const char* sec)
-{
-    int ret = 1;
-    char *direction;
-    /* If chaining is not enabled, add qdisc */
-    ret = validate_filter_args(dev);
-    if (!ret)
-        return 0;
-
-    if(chain != true) {
-        char *qdisc_cmd[] = {tc_cmd , "qdisc", "add", "dev", (void *)dev, "clsact", (char*)0};
-        ret = exec_cmd(qdisc_cmd) ;
-        /* Ignoring error, in case qdisc already added by any other process*/
-        if( ret < 0)
-            log_err("tc qdisc add failed");
-    }
-
-    if(dir == INGRESS) {
-        direction = (void *)ingress_dir;
-    } else {
-        direction = (void *)egress_dir;
-    }
-
-    char *filter_cmd[] = {tc_cmd, "filter", "add", "dev", (void *)dev, direction,
-                          "prio", "1", "handle", "1", "bpf", "da", "obj",
-                           (void *)bpf_obj, "sec", (void *)sec, (char*)0};
-
-    /* Attach tc filter */
-    ret = exec_cmd(filter_cmd) ;
-    if( ret < 0) {
-        /* Exit with failed status*/
-        perror("tc filter attach failed");
-	close_logfile();
-        exit(EXIT_FAILURE);
-    }
-    return 1;
-}
-
-int tc_cmd_filter(const char* dev, int dir, const char* action)
-{
-    int ret = 0;
-    const char *direction;
-
-    if(dir == INGRESS) {
-        direction = ingress_dir;
-    } else {
-        direction = egress_dir;
-    }
-    if (!validate_str(direction))
-        return 0;
-
-    char* filter_cmd[] = {tc_cmd, "filter", (void *)action, "dev", (void *)dev, (void *)direction, (char*)0};
-    /* Attach tc filter */
-    ret = exec_cmd(filter_cmd) ;
-    if( ret < 0) {
-        /* Exit with failed status*/
-        perror("tc filter attach failed");
-        close_logfile();
-        exit(EXIT_FAILURE);
-    }
-    return ret;
-}
-
-int tc_remove_filter(const char* dev, int dir)
-{
-    int ret = 0;
-    const char *act = "del";
-    ret = tc_cmd_filter(dev, dir, act);
-    return ret;
-}
-
-// This method to unlink the program
-int tc_remove_bpf(const char *map_filename) {
-     int ret;
-     int key = 0;
-     int map_fd = bpf_obj_get(map_filename);
-     if (map_fd < 0) {
-         fprintf(stderr, "ERROR: map_fd of map not found: %s\n", strerror(map_fd));
-         return -1;
-     }
-
-     ret = bpf_map_delete_elem(map_fd, &key);
-     if (ret != 0) {
-         fprintf(stderr, "ERROR(%d): tc chain remove program failed \n", ret);
-     }
-     return ret;
-}
-
 bool validate_ifname(const char* input_ifname, char *output_ifname)
 {
     size_t len;
@@ -457,66 +363,6 @@ FILE* set_logfile(const char *file_name) {
     return info;
 }
 
-int validate_chain_args(const char *map_name) {
-    int ret = 1;
-    if (!validate_map_name(map_name)) {
-        return 0;
-    }
-    return ret;
-}
-
-int  tc_chain_bpf(const char *map_name, const char *bpf_obj, const char *sec) {
-    int ret = 1;
-    ret = validate_chain_args(map_name);
-    if(!ret)
-        return 0;
-
-    char *cmd[] = {"/sbin/tc" , "exec", "bpf", "graft", (void *)map_name, "key",
-                   "0", "obj", (void *)bpf_obj, "sec", (void *)sec, (char*)0};
-
-    /* Attach tc graft */
-    ret = exec_cmd(cmd) ;
-    if( ret < 0) {
-        /* Exit with failed status*/
-        perror("tc exec bpf graft failed");
-        close_logfile();
-        exit(EXIT_FAILURE);
-    }
-    return 1;
-}
-
-void tc_cleanup( bool chain, char *if_name, int dir,
-		 const char* bpf_map,
-		 const char* last_bpf_map,
-		 char* bpf_map_file_path,
-		 const char* ipfix_jmp_table) {
-    int ret = 0;
-    if (remove(last_bpf_map) < 0)
-        fprintf(stderr, "Failed to remove map file - last_bpf_map\n");
-    if (remove(bpf_map) < 0)
-        fprintf(stderr, "Failed to remove map file - bpf_map\n");
-    if (remove(ipfix_jmp_table) < 0)
-        fprintf(stderr, "Failed to remove map file - ipfix_jmp_table\n");
-
-    if (!chain) {
-        ret = tc_remove_filter(if_name, dir);
-        if(ret) {
-	    fprintf(stderr,"ERR(%d): tc remove filter failed \n",
-                WEXITSTATUS(ret));
-	}
-    }
-    else {
-        ret = tc_remove_bpf(bpf_map_file_path);
-        if(ret) {
-	    fprintf(stderr,"ERR(%d): tc remove filter failed \n",
-                WEXITSTATUS(ret));
-	}
-    }
-    if (bpf_map_file_path != NULL)
-        free(bpf_map_file_path);
-    return;
-}
-
 void flow_record_poll(int map_fd, int last_map_fd, int dir)
 {
     bool ipfix_required = false;
@@ -559,4 +405,16 @@ int get_length(const char *str)
        len++;
 
    return len;
+}
+
+/* Map filepath is created by l3afd */
+int get_bpf_map_file(const char *ifname, const char *map_name, char *map_file)
+{
+    snprintf(map_file, MAP_PATH_SIZE, "%s/%s/%s", map_base_dir, ifname, map_name);
+    log_info("map path filename %s", map_file);
+    struct stat st = {0};
+    if (stat(map_file, &st) != 0) {
+        return -1;
+    }
+    return 0;
 }

--- a/ipfix-flow-exporter/bpf_ipfix_user.h
+++ b/ipfix-flow-exporter/bpf_ipfix_user.h
@@ -38,9 +38,9 @@ extern const char* ingress_bpf_map ;
 extern const char* last_ingress_bpf_map ;
 extern const char* ipfix_ingress_jmp_table;
 extern const char* ipfix_egress_jmp_table;
-extern const char* bpf_path;
 extern const char* ingress_dir;
 extern const char* egress_dir;
+static const char map_base_dir[] = "/sys/fs/bpf/tc/globals";
 
 extern bool chain;
 extern char *remote_ip, *bpf_map_file_path, *tc_cmd;
@@ -54,6 +54,7 @@ enum iface_direction {
   EGRESS  = 1,
 };
 
+#define MAP_PATH_SIZE   1024
 
 unsigned long get_current_time_ns(void);
 void get_random_number(unsigned int *fid);
@@ -124,4 +125,6 @@ bool validate_map(const char* input);
 int tc_cmd_filter(const char* dev, int dir, const char* action);
 
 int validate_chain_args(const char *map_name);
+
+int get_bpf_map_file(const char *ifname, const char *map_name, char *map_file);
 #endif


### PR DESCRIPTION
This PR is to make changes to the ipfix flow exporter program to load from the l3afd. Specifically, the modification involves removing the loading and chaining functionality from the user program. Secondly, program SEC names are prefixed with keyword `tc`, Thirdly, bpf map definition are updated from SEC("maps") to SEC(".maps") format. Additionally, maps will be accessed from a directory path specific to the interface, which is located at `/sys/bpf/fs/tc/globals/<iface>`.