### PR TITLE
removed redundent free stmts

### DIFF
--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -926,8 +926,8 @@ int main(int argc, char **argv)
                     perror("ERROR: bpf_map_update_elem");
                     ret = EXIT_FAILURE;
                 }
-                free(src_key);
             }
+            free(src_key);
         }
     }
 
@@ -964,8 +964,8 @@ int main(int argc, char **argv)
                     perror("ERROR: bpf_map_update_elem");
                     ret = EXIT_FAILURE;
                 }
-                free(dst_key);
             }
+            free(dst_key);
         }
     }
     int key = 0;

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -925,8 +925,8 @@ int main(int argc, char **argv)
                     log_err("Failed to update source endpoint bpf map");
                     perror("ERROR: bpf_map_update_elem");
                     ret = EXIT_FAILURE;
-                    free(src_key);
                 }
+                free(src_key);
             }
         }
     }
@@ -958,14 +958,13 @@ int main(int argc, char **argv)
                             "address %s",
                             dst_addr[i].addr);
                     ret = EXIT_FAILURE;
-                    free(dst_key);
                 }
                 if (bpf_map_update_elem(dst_fd, dst_key, &dst_val, 0) < 0) {
                     log_err("Failed to update destination endpoint bpf map");
                     perror("ERROR: bpf_map_update_elem");
                     ret = EXIT_FAILURE;
-                    free(dst_key);
                 }
+                free(dst_key);
             }
         }
     }

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -928,7 +928,6 @@ int main(int argc, char **argv)
                     free(src_key);
                 }
             }
-            free(src_key);
         }
     }
 
@@ -968,7 +967,6 @@ int main(int argc, char **argv)
                     free(dst_key);
                 }
             }
-            free(dst_key);
         }
     }
     int key = 0;

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -919,6 +919,7 @@ int main(int argc, char **argv)
                     log_err("Error converting source address to network "
                             "address %s",
                             src_addr[i].addr);
+		    free(src_key);
                     return (EXIT_FAILURE);
                 }
                 if (bpf_map_update_elem(src_fd, src_key, &src_val, 0) < 0) {
@@ -957,7 +958,8 @@ int main(int argc, char **argv)
                     log_err("Failed to convert destination address to network "
                             "address %s",
                             dst_addr[i].addr);
-                    ret = EXIT_FAILURE;
+		    free(dst_key);
+                    return (EXIT_FAILURE);
                 }
                 if (bpf_map_update_elem(dst_fd, dst_key, &dst_val, 0) < 0) {
                     log_err("Failed to update destination endpoint bpf map");

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -966,7 +966,7 @@ int main(int argc, char **argv)
                     log_err("Failed to update destination endpoint bpf map");
                     perror("ERROR: bpf_map_update_elem");
                     free(dst_key);
-		            return (EXIT_FAILURE);
+		    return (EXIT_FAILURE);
                 }
             }
             free(dst_key);

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -964,7 +964,7 @@ int main(int argc, char **argv)
                 if (bpf_map_update_elem(dst_fd, dst_key, &dst_val, 0) < 0) {
                     log_err("Failed to update destination endpoint bpf map");
                     perror("ERROR: bpf_map_update_elem");
-                    ret = EXIT_FAILURE;
+		    return (EXIT_FAILURE);
                 }
             }
             free(dst_key);

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -883,7 +883,7 @@ int main(int argc, char **argv)
                                   &tunnel_ifindex, 0);
         if (ret) {
             perror("ERROR: bpf_map_update_elem");
-            ret = EXIT_FAILURE;
+            return EXIT_FAILURE;
         }
         if (verbose) {
             log_info("Change egress redirect ifindex to: %d", tunnel_ifindex);
@@ -919,13 +919,14 @@ int main(int argc, char **argv)
                     log_err("Error converting source address to network "
                             "address %s",
                             src_addr[i].addr);
-		    free(src_key);
+		            free(src_key);
                     return (EXIT_FAILURE);
                 }
                 if (bpf_map_update_elem(src_fd, src_key, &src_val, 0) < 0) {
                     log_err("Failed to update source endpoint bpf map");
                     perror("ERROR: bpf_map_update_elem");
-                    ret = EXIT_FAILURE;
+                    free(src_key);
+                    return (EXIT_FAILURE);
                 }
             }
             free(src_key);
@@ -958,13 +959,14 @@ int main(int argc, char **argv)
                     log_err("Failed to convert destination address to network "
                             "address %s",
                             dst_addr[i].addr);
-		    free(dst_key);
+		            free(dst_key);
                     return (EXIT_FAILURE);
                 }
                 if (bpf_map_update_elem(dst_fd, dst_key, &dst_val, 0) < 0) {
                     log_err("Failed to update destination endpoint bpf map");
                     perror("ERROR: bpf_map_update_elem");
-		    return (EXIT_FAILURE);
+                    free(dst_key);
+		            return (EXIT_FAILURE);
                 }
             }
             free(dst_key);
@@ -985,7 +987,7 @@ int main(int argc, char **argv)
         ret = bpf_map_update_elem(ingress_any_fd, &key, &any_rep_ingress, 0);
         if (ret) {
             perror("ERROR: bpf_map_update_elem");
-            ret = EXIT_FAILURE;
+            return EXIT_FAILURE;
         }
     } else if (strcmp(direction, EGRESS) == 0) {
         if (src_port_filter) {
@@ -1000,7 +1002,7 @@ int main(int argc, char **argv)
         ret = bpf_map_update_elem(egress_any_fd, &key, &any_rep_egress, 0);
         if (ret) {
             perror("ERROR: bpf_map_update_elem");
-            ret = EXIT_FAILURE;
+            return EXIT_FAILURE;
         }
     }
 


### PR DESCRIPTION
Basically some free stmts are used even after **src_key** become null. In this PR I have addressed this issue

I have done testing of datapath and loading for  both ingress and egress on my local setup.