### PR TITLE
Fix to allow all tunnel types for encapsulating mirrored traffic

### DIFF
--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -196,13 +196,7 @@ bool validate_netlink(struct route_config *r)
         fprintf(stderr, "ERR: No routing information provided\n");
         return false;
     }
-    if (strcmp(r->encap_type, "gue") == 0) {
-        r->type = "ipip";
-        r->name = "gue1";
-    } else {
-        fprintf(stderr, "ERR: --tunnel-type unknown value\n");
-        return false;
-    }
+    r->name = "tunnelRoute";
 
     getifaddrs(&ifap);
     for (ifa = ifap; ifa; ifa = ifa->ifa_next) {


### PR DESCRIPTION
Removing restrictions to only allow GUE tunnel. Additionally, this PR is tested with GRE tunnel on Vagrant environment.
TODO: Test with other tunnel types as SIT