### PR TITLE
interface validation to include hyphen

### DIFF
--- a/connection-limit/connection_limit_user.c
+++ b/connection-limit/connection_limit_user.c
@@ -446,7 +446,7 @@ static bool validate_ifname(const char *input_ifname, char *output_ifname)
   {
     char c = input_ifname[i];
 
-    if (!(isalpha(c) || isdigit(c)))
+    if (!(isalpha(c) || isdigit(c) || c == '-'))
     {
       return false;
     }

--- a/examples/tc/tcprog_user.c
+++ b/examples/tc/tcprog_user.c
@@ -64,7 +64,7 @@ static bool validate_ifname(const char *input_ifname, char *output_ifname) {
     for (i = 0; i < len; i++) {
         char c = input_ifname[i];
 
-        if (!(isalpha(c) || isdigit(c)))
+        if (!(isalpha(c) || isdigit(c) || c == '-'))
             return false;
     }
     strncpy(output_ifname, input_ifname, len);

--- a/ipfix-flow-exporter/bpf_ipfix_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_user.c
@@ -192,7 +192,7 @@ bool validate_ifname(const char* input_ifname, char *output_ifname)
     for (i = 0; i < len; i++) {
         char c = input_ifname[i];
 
-        if (!(isalpha(c) || isdigit(c)))
+        if (!(isalpha(c) || isdigit(c) || c == '-'))
             return false;
     }
     iface = (void *)input_ifname;

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -490,7 +490,7 @@ static bool validate_ifname(const char *input_ifname, char *output_ifname)
     {
         char c = input_ifname[i];
 
-        if (!(isalpha(c) || isdigit(c)))
+        if (!(isalpha(c) || isdigit(c) || c == '-'))
         {
             return false;
         }


### PR DESCRIPTION
Currently Our eBPF Programs error out if network interface name contains hyphen character. In this PR I have fix this problem. #25 