### PR TITLE
Fixing traffic-mirroing build issue #100

### DIFF
--- a/.github/workflows/ci-build-ubuntu.yaml
+++ b/.github/workflows/ci-build-ubuntu.yaml
@@ -85,37 +85,37 @@ jobs:
           bash buildscript.sh
 
       - name: Upload xdp-root
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xdp-root-linux-artifact
           path: ${{ env.LINUX_SRC_PATH }}/${{ env.BPF_PATH }}/${{ env.REPO }}/xdp-root/l3af_xdp_root/*
 
       - name: Upload ratelimiting
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ratelimiting-linux-artifact
           path: ${{ env.LINUX_SRC_PATH }}/${{ env.BPF_PATH }}/${{ env.REPO }}/ratelimiting/l3af_ratelimiting/*
 
       - name: Upload connection-limit
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: connection-limit-linux-artifact
           path: ${{ env.LINUX_SRC_PATH }}/${{ env.BPF_PATH }}/${{ env.REPO }}/connection-limit/l3af_connection_limit/*
 
       - name: Upload tc-root
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tc-root-linux-artifact
           path: ${{ env.LINUX_SRC_PATH }}/${{ env.BPF_PATH }}/${{ env.REPO }}/tc-root/l3af_tc_root/*
 
       - name: Upload ipfix-flow-exporter
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ipfix-flow-exporter-linux-artifact
           path: ${{ env.LINUX_SRC_PATH }}/${{ env.BPF_PATH }}/${{ env.REPO }}/ipfix-flow-exporter/l3af_bpf_ipfix/*
 
       - name: Upload traffic-mirroring
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: traffic-mirroring-linux-artifact
           path: ${{ env.LINUX_SRC_PATH }}/${{ env.BPF_PATH }}/${{ env.REPO }}/traffic-mirroring/l3af_traffic_mirroring/*

--- a/.github/workflows/ci-build-windows.yaml
+++ b/.github/workflows/ci-build-windows.yaml
@@ -44,13 +44,13 @@ jobs:
           copy D:\a\eBPF-Package-Repository\eBPF-Package-Repository\ratelimiting\build\ratelimiting_kern.o upload_artifact_ratelimiting
 
       - name: Upload xdp-root
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: xdp-root-windows-${{env.BUILD_CONFIGURATION}}-artifact
           path: upload_artifact_xdp_root
 
       - name: Upload ratelimiting
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ratelimiting-windows-${{env.BUILD_CONFIGURATION}}-artifact
           path: upload_artifact_ratelimiting

--- a/traffic-mirroring/mirroring_egress.bpf.c
+++ b/traffic-mirroring/mirroring_egress.bpf.c
@@ -10,6 +10,7 @@
 #include "vmlinux.h"
 #include "bpf_helpers.h"
 #include "bpf_endian.h"
+
 #define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
 #define ETH_P_ARP	0x0806		/* Address Resolution packet	*/
 #define ETH_HLEN	14		/* Total octets in header.	 */
@@ -26,7 +27,7 @@ struct daddr_key {
 };
 
 #define MAX_ADDRESSES 50
-#define KEY_SIZE_IPV4 sizeof(struct bpf_lpm_trie_key) + sizeof(__u32)
+#define KEY_SIZE_IPV4 sizeof(__u32) + sizeof(__u8) + sizeof(__u32)
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);

--- a/traffic-mirroring/mirroring_egress.bpf.c
+++ b/traffic-mirroring/mirroring_egress.bpf.c
@@ -10,7 +10,7 @@
 #include "vmlinux.h"
 #include "bpf_helpers.h"
 #include "bpf_endian.h"
-
+#include "bpf/bpf.h"
 #define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
 #define ETH_P_ARP	0x0806		/* Address Resolution packet	*/
 #define ETH_HLEN	14		/* Total octets in header.	 */
@@ -27,7 +27,7 @@ struct daddr_key {
 };
 
 #define MAX_ADDRESSES 50
-#define KEY_SIZE_IPV4 sizeof(__u32) + sizeof(__u8) + sizeof(__u32)
+#define KEY_SIZE_IPV4 sizeof(struct bpf_lpm_trie_key) + sizeof(__u32)
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);

--- a/traffic-mirroring/mirroring_ingress.bpf.c
+++ b/traffic-mirroring/mirroring_ingress.bpf.c
@@ -10,6 +10,7 @@
 #include "vmlinux.h"
 #include "bpf_endian.h"
 #include "bpf_helpers.h"
+#include "bpf/bpf.h"
 #define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
 #define ETH_P_ARP	0x0806		/* Address Resolution packet	*/
 #define ETH_HLEN	14		/* Total octets in header.	 */
@@ -26,7 +27,7 @@ struct saddr_key {
 };
 
 #define MAX_ADDRESSES 50
-#define KEY_SIZE_IPV4 sizeof(__u32) + sizeof(__u8) + sizeof(__u32)
+#define KEY_SIZE_IPV4 sizeof(struct bpf_lpm_trie_key) + sizeof(__u32)
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);

--- a/traffic-mirroring/mirroring_ingress.bpf.c
+++ b/traffic-mirroring/mirroring_ingress.bpf.c
@@ -26,7 +26,7 @@ struct saddr_key {
 };
 
 #define MAX_ADDRESSES 50
-#define KEY_SIZE_IPV4 sizeof(struct bpf_lpm_trie_key) + sizeof(__u32)
+#define KEY_SIZE_IPV4 sizeof(__u32) + sizeof(__u8) + sizeof(__u32)
 
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);


### PR DESCRIPTION
Issue: https://github.com/l3af-project/eBPF-Package-Repository/issues/100

The struct bpf_lpm_trie_key was not being referenced while using the sizeof function. In the new changes, include bpf.h, which contains the definition of the struct. 
