### PR TITLE
Configure dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Copyright Contributors to the L3AF Project.
+# SPDX-License-Identifier: Apache-2.0
+#
+# For documentation on the format of this file, see
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    # Workflow files are stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
​This PR sets up Dependabot to manage and update GitHub Actions dependencies. 