### PR TITLE
Update the version argument for the bpf programs

### DIFF
--- a/connection-limit/constants.h
+++ b/connection-limit/constants.h
@@ -18,6 +18,7 @@ static const char *conn_count_map_name = "cl_conn_count";
 static const char *tcp_conns_map_name = "cl_tcp_conns";
 static const char *conn_info_map_name = "cl_conn_info";
 static const char map_base_dir[] = "/sys/fs/bpf";
+static const char *prog_name = "connection-limit";
 
 /* Port separator */
 const char delim[] = ",";

--- a/ipfix-flow-exporter/bpf_ipfix_egress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_egress_user.c
@@ -33,9 +33,9 @@ void sig_handler(int signo)
     exit(EXIT_SUCCESS);
 }
 
-int populate_egress_fds(void) {
+int populate_egress_fds(const char *version) {
     char map_file[MAP_PATH_SIZE];
-    if (get_bpf_map_file(if_name, egress_bpf_map, map_file) < 0) {
+    if (get_bpf_map_file(if_name, version, egress_bpf_map, map_file) < 0) {
         fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
         return EXIT_FAILURE;
     }
@@ -47,7 +47,7 @@ int populate_egress_fds(void) {
         return EXIT_FAILURE;
     }
 
-    if (get_bpf_map_file(if_name, last_egress_bpf_map, map_file) < 0) {
+    if (get_bpf_map_file(if_name, version, last_egress_bpf_map, map_file) < 0) {
         fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
         return EXIT_FAILURE;
     }
@@ -66,6 +66,7 @@ int main(int argc, char **argv)
     verbosity = LOG_INFO;
     long flow_timeout = 0;
     char *eptr;
+    char *version;
     /* Parse commands line args */
     while ((opt = getopt_long(argc, argv, "hq",
                   long_options, &long_index)) != -1) {
@@ -101,7 +102,11 @@ int main(int argc, char **argv)
                     remote_port = (int)(strtol(optarg, &eptr, 10));
                 break;
             case 'd':
-		break;
+	            break;
+            case 'v':
+                if(optarg)
+                    version = optarg;
+                break;
             case 'h':
             default:
                 usage(argv, __doc__);
@@ -116,7 +121,7 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    if (populate_egress_fds() == EXIT_FAILURE) {
+    if (populate_egress_fds(version) == EXIT_FAILURE) {
         fprintf(stderr, "ERR: Fetching TC EGRESS maps failed\n");
         close_logfile();
         close_egress_fds();

--- a/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_ingress_user.c
@@ -32,9 +32,9 @@ void sig_handler(int signo)
     exit(EXIT_SUCCESS);
 }
 
-int populate_ingress_fds(void) {
+int populate_ingress_fds(const char *version) {
     char map_file[MAP_PATH_SIZE];
-    if (get_bpf_map_file(if_name, ingress_bpf_map, map_file) < 0) {
+    if (get_bpf_map_file(if_name, version, ingress_bpf_map, map_file) < 0) {
         fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
         return EXIT_FAILURE;
     }
@@ -45,7 +45,7 @@ int populate_ingress_fds(void) {
         return EXIT_FAILURE;
     }
 
-    if (get_bpf_map_file(if_name, last_ingress_bpf_map, map_file) < 0) {
+    if (get_bpf_map_file(if_name, version, last_ingress_bpf_map, map_file) < 0) {
         fprintf(stderr, "ERROR: map file path (%s) doesn't exists", map_file);
         return EXIT_FAILURE;
     }
@@ -65,6 +65,7 @@ int main(int argc, char **argv)
     verbosity = LOG_INFO;
     long flow_timeout = 0;
     char *eptr;
+    char *version;
 
     /* Parse commands line args */
     while ((opt = getopt_long(argc, argv, "hq",
@@ -100,9 +101,12 @@ int main(int argc, char **argv)
                 if(optarg)
                     remote_port = (int)(strtol(optarg, &eptr, 10));
                 break;
+            case 'v' :
+                if(optarg)
+                    version = optarg;
             case 'd':
 		/* This option is to have consistancy across NFs */
-		break;
+		    break;
             case 'h':
             default:
                 usage(argv, __doc__);
@@ -117,7 +121,7 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
-    if (populate_ingress_fds() == EXIT_FAILURE) {
+    if (populate_ingress_fds(version) == EXIT_FAILURE) {
         fprintf(stderr, "ERR: Fetching TC INGRESS maps failed\n");
         close_logfile();
         close_ingress_fds();

--- a/ipfix-flow-exporter/bpf_ipfix_user.c
+++ b/ipfix-flow-exporter/bpf_ipfix_user.c
@@ -31,6 +31,7 @@ const struct option long_options[] = {
     {"collector_ip", required_argument, NULL, 'c' },
     {"direction", required_argument, NULL, 'd' },
     {"collector_port", required_argument, NULL, 'p' },
+    {"version", required_argument, NULL, 'v'},
     {"flow-timeout", optional_argument, NULL, 't' },
     {"verbose (allowed 0-4, 0-NO_LOG,1-LOG_DEBUG,2-LOG_INFO,3-LOG_WARN,4-LOG_ERR,5-LOG_CRIT)", optional_argument, NULL, 'q' },
     {0, 0, NULL,  0 }
@@ -382,9 +383,9 @@ int get_length(const char *str)
 }
 
 /* Map filepath is created by l3afd */
-int get_bpf_map_file(const char *ifname, const char *map_name, char *map_file)
+int get_bpf_map_file(const char *ifname,  const char *version, const char *map_name, char *map_file)
 {
-    snprintf(map_file, MAP_PATH_SIZE, "%s/%s/%s", map_base_dir, ifname, map_name);
+    snprintf(map_file, MAP_PATH_SIZE, "%s/%s/%s/%s/%s", map_base_dir, ifname, prog_name, version, map_name);
     log_info("map path filename %s", map_file);
     struct stat st = {0};
     if (stat(map_file, &st) != 0) {

--- a/ipfix-flow-exporter/bpf_ipfix_user.h
+++ b/ipfix-flow-exporter/bpf_ipfix_user.h
@@ -40,7 +40,7 @@ extern const char* ipfix_egress_jmp_table;
 extern const char* ingress_dir;
 extern const char* egress_dir;
 static const char map_base_dir[] = "/sys/fs/bpf/tc/globals";
-
+static const char *prog_name = "ipfix-flow-exporter";
 extern bool chain;
 extern char *remote_ip, *bpf_map_file_path, *tc_cmd;
 extern int flow_timeout, remote_port, bpf_map_fd;
@@ -89,9 +89,9 @@ int validate_str(const char *str);
 
 void sig_handler(int signo);
 
-int populate_egress_fds(void);
+int populate_egress_fds(const char *version);
 
-int populate_ingress_fds(void);
+int populate_ingress_fds(const char *version);
 
 void cpy(char *src,char *des);
 
@@ -99,7 +99,7 @@ bool validate_map_name(const char *path);
 
 bool validate_map(const char* input);
 
-int get_bpf_map_file(const char *ifname, const char *map_name, char *map_file);
+int get_bpf_map_file(const char *ifname, const char *version, const char *map_name, char *map_file);
 
 void close_fd(int fd);
 void close_ingress_fds(void);

--- a/traffic-mirroring/mirroring.c
+++ b/traffic-mirroring/mirroring.c
@@ -301,6 +301,7 @@ static const struct option long_options[] = {
     {"help", no_argument, NULL, 'h'},
     {"iface", required_argument, NULL, 'i'},
     {"redirect-to", required_argument, NULL, 'e'},
+    {"version", required_argument, NULL, 'v'},
     /* HINT assign: optional_arguments with '=' */
     { "direction", optional_argument, NULL, 't' },
     { "src-address", optional_argument, NULL, 's' },
@@ -667,9 +668,9 @@ static void update_proto(int map_fd, char *protocols)
 }
 
 /* validate map file path */
-int get_bpf_map_file(const char *ifname, const char *map_name, char *map_file)
+int get_bpf_map_file(const char *ifname, const char *version, const char *map_name, char *map_file)
 {
-    snprintf(map_file, MAP_PATH_SIZE, "%s/%s/%s", map_base_dir, ifname, map_name);
+    snprintf(map_file, MAP_PATH_SIZE, "%s/%s/%s/%s/%s", map_base_dir, ifname, prog_name, version, map_name);
     log_info("map path filename %s", map_file);
     struct stat st = {0};
     if (stat(map_file, &st) != 0)
@@ -700,6 +701,7 @@ int main(int argc, char **argv)
     int slen = 0, dlen = 0, tmplen = 0, glen = 0;
     int ret = EXIT_SUCCESS;
     char map_file[MAP_PATH_SIZE];
+    char *version;
 
     memset(ifname, 0, IF_NAMESIZE); /* Can be used uninitialized */
     fprintf(stdout, "DEFAULT_LOGFILE is %s\n", DEFAULT_LOGFILE);
@@ -839,6 +841,9 @@ int main(int argc, char **argv)
         case 'q':
             verbose = 0;
             break;
+        case 'v':
+            if(optarg)
+               version = optarg;
         case 'h':
         default:
             usage(argv);
@@ -861,7 +866,7 @@ int main(int argc, char **argv)
     fflush(info);
 
     memset(map_file, '\0', MAP_PATH_SIZE);
-    if (get_bpf_map_file(ifname, redirect_mapfile, map_file) < 0)
+    if (get_bpf_map_file(ifname, version, redirect_mapfile, map_file) < 0)
     {
         log_err("ERROR: map file path (%s) doesn't exists", map_file);
         cleanup();
@@ -880,7 +885,7 @@ int main(int argc, char **argv)
     if (strcmp(direction, INGRESS) == 0)
     {
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, src_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, src_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -896,7 +901,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, ingress_src_port_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, ingress_src_port_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -912,7 +917,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, ingress_dst_port_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, ingress_dst_port_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -927,7 +932,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, ingress_proto_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, ingress_proto_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -943,7 +948,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, ingress_any_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, ingress_any_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -962,7 +967,7 @@ int main(int argc, char **argv)
     else if (strcmp(direction, EGRESS) == 0)
     {
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, dst_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, dst_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -978,7 +983,7 @@ int main(int argc, char **argv)
         }
 
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, egress_src_port_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, egress_src_port_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -994,7 +999,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, egress_dst_port_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, egress_dst_port_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -1009,7 +1014,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, egress_proto_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, egress_proto_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();
@@ -1024,7 +1029,7 @@ int main(int argc, char **argv)
             ret = EXIT_FAILURE;
         }
         memset(map_file, '\0', MAP_PATH_SIZE);
-        if (get_bpf_map_file(ifname, egress_any_mapfile, map_file) < 0)
+        if (get_bpf_map_file(ifname, version, egress_any_mapfile, map_file) < 0)
         {
             log_err("ERROR: map file path (%s) doesn't exists", map_file);
             cleanup();

--- a/traffic-mirroring/mirroring.h
+++ b/traffic-mirroring/mirroring.h
@@ -66,6 +66,7 @@ static const char *ingress_any_mapfile = "ingress_any";
 static const char *egress_any_mapfile = "egress_any";
 static const char map_base_dir[] = "/sys/fs/bpf/tc/globals";
 static int verbose = 1;
+static const char *prog_name = "traffic-mirroring";
 
 static bool validate_ifname(const char* input_ifname, char *output_ifname);
 static bool validate_address(char* input_address, network_addr_t output_address[], int *count);


### PR DESCRIPTION
This PR adds version argument to userprograms. To access BPF maps from the pinned location, which includes the program name and version in the path.

New map file dir will be `/sys/fs/bpf/tc/globals/<iface>/<prog-name>/<version>` or `/sys/fs/bpf/<iface>/<prog-name>/<version>`
